### PR TITLE
Comply with PJRC's license

### DIFF
--- a/nano_gui.cpp
+++ b/nano_gui.cpp
@@ -1,10 +1,32 @@
+/* Portions of this file are derived under the following license:
+ *
+ * Touchscreen library for XPT2046 Touch Controller Chip
+ * Copyright (c) 2015, Paul Stoffregen, paul@pjrc.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice, development funding notice, and this permission
+ * notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 #include <Arduino.h>
 #include <EEPROM.h>
 #include "ubitx.h"
 #include "nano_gui.h"
 
 //#include "Adafruit_GFX.h"
-//#include <XPT2046_Touchscreen.h>
 #include <SPI.h>
 #include <avr/pgmspace.h>
 


### PR DESCRIPTION
The XPT2046_Touchscreen library is MIT-licensed, so we're required to include its copyright notice somewhere when excerpting/adapting that code.

If the other parts of the file were adapted from the Adafruit_GFX library, we should probably add their [BSD license text](https://github.com/adafruit/Adafruit-GFX-Library/blob/master/license.txt) as well.